### PR TITLE
Include access token into query header

### DIFF
--- a/src/de/uni_passau/fim/gitwrapper/GitHubRepository.java
+++ b/src/de/uni_passau/fim/gitwrapper/GitHubRepository.java
@@ -717,9 +717,12 @@ public class GitHubRepository extends Repository {
                         // return Optional.empty();
                     }
 
-                    String httpURL = url + (token.getToken().get().isEmpty() ? "" : "&access_token=" + token.getToken().get());
-                    LOG.info("Querying URL: " + httpURL);
-                    CloseableHttpResponse resp = hc.execute(new HttpGet(httpURL));
+                    LOG.info("Querying URL: " + url);
+                    HttpGet request = new HttpGet(url);
+                    if (!token.getToken().get().isEmpty()) {
+                        request.addHeader("Authorization", "token " + token.getToken().get());
+                    }
+                    CloseableHttpResponse resp = hc.execute(request);
 
                     Map<String, List<String>> headers = Arrays.stream(resp.getAllHeaders())
                             .collect(Collectors.toMap(Header::getName,


### PR DESCRIPTION
Using GitHub access tokens as query parameters is deprecated from now
on:

https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

Hence, include the access token into the query header instead.

This fixes #27.

Props to @fheck for providing this patch very quickly! I have tested it on a few small projects and it worked.