### PR TITLE
Minor fixes to prevent crashing

### DIFF
--- a/src/de/uni_passau/fim/gitwrapper/GitHubRepository.java
+++ b/src/de/uni_passau/fim/gitwrapper/GitHubRepository.java
@@ -481,7 +481,7 @@ public class GitHubRepository extends Repository {
                                     return false;
                                 } else {
 
-                                    // Comment is a reply. Now we need to check whether to referenced comment belongs to the review of interest.
+                                    // Comment is a reply. Now we need to check whether the referenced comment belongs to the review of interest.
                                     refReviewId = commentReviewMap.get(inReplyTo.getAsInt());
 
                                     if (refReviewId != null && refReviewId == reviewId) {


### PR DESCRIPTION
This PR contains two minor fixes to prevent crashing of the GitHubWrapper during running analyses:

(1) Add precautionary `isPresent()` checks when accessing review comments. This way, no `NoSuchElementException` is thrown when calling the `get()` function of an `Optional<List<JsonElement>>`. In the case that there is no review comment, just use an empty list instead of accessing the `Optional` object.

(2) Retry querying data from an URL if a query results in an `IOException` as, in most cases, this is caused by network connection issues or temporary availability issues. Hence, retrying (after waiting for 5 seconds) might help in most cases. This way, we don't have to deal with subsequent exceptions and just retry the query until we get the expected response :wink:.