### PR TITLE
Adding support for external commits in `referenced` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ java -Xmx100G -jar "build/libs/GitHubWrapper-1.0-SNAPSHOT.jar" \
 - Using the `-repo` parameter, you specify the file path of the repo you want to analyze. Notice that you need to have cloned the repo locally, such that the origin can be derived from this file path.
 - Using the `-workDir` parameter, you specify the working directory, which usually is the directory which contains the repository directory specified at `-repo`.
 
+### `Referenced` events
+
+`Referenced` events are events generated in an issue if a commit references that issue in its commit message. The intended behavior is, that the event is present in the issue's event data, and the commit is again present in the related commits of the issue. This does not work if it is not possible to fetch that commit. In this case, the event still exists, but it contains a link to a commit that the api cannot resolve, meaning that no data about the commit can be accessed. This may lead to incorrect data points if the resulting data is automatically processed, for example using the tool `codeface-extraction`. Known causes of this include:
+
+- a commit was rebased and changed/removed
+- an external repository was deleted
+- the commit's branch was deleted
+
+Note that the commit might still be reachable until the automatic garbage collection has removed it from the remote repository.
+
 ### Integration into other projects
 
 There is also an option to use the implementation of GitHubWrapper in your code without using the provided `IssueRunner`.

--- a/README.md
+++ b/README.md
@@ -43,16 +43,6 @@ java -Xmx100G -jar "build/libs/GitHubWrapper-1.0-SNAPSHOT.jar" \
 - Using the `-repo` parameter, you specify the file path of the repo you want to analyze. Notice that you need to have cloned the repo locally, such that the origin can be derived from this file path.
 - Using the `-workDir` parameter, you specify the working directory, which usually is the directory which contains the repository directory specified at `-repo`.
 
-### `Referenced` events
-
-`Referenced` events are events generated in an issue if a commit references that issue in its commit message. The intended behavior is, that the event is present in the issue's event data, and the commit is again present in the related commits of the issue. This does not work if it is not possible to fetch that commit. In this case, the event still exists, but it contains a link to a commit that the api cannot resolve, meaning that no data about the commit can be accessed. This may lead to incorrect data points if the resulting data is automatically processed, for example using the tool `codeface-extraction`. Known causes of this include:
-
-- a commit was rebased and changed/removed
-- an external repository was deleted
-- the commit's branch was deleted
-
-Note that the commit might still be reachable until the automatic garbage collection has removed it from the remote repository.
-
 ### Integration into other projects
 
 There is also an option to use the implementation of GitHubWrapper in your code without using the provided `IssueRunner`.
@@ -101,3 +91,19 @@ repo.getIssues(false).ifPresent(issueData -> issueData.forEach(issue -> {
         System.out.println(comment.user.username + ": " + comment.body));
 }));
 ```
+
+### Further data processing
+
+The data extracted by this tool can be further processed, for example using the `run-issues.py` skript from the tool [`codeface-extraction`](https://github.com/se-sic/codeface-extraction). This organises and unifies the issue data into a single .list file. It also allows for synchronisation with data from other data extraction tools, such as `codeface`.
+
+### `Referenced` events
+
+`Referenced` events are events generated in an issue if a commit references that issue in its commit message. The intended behavior is that the event is present in the issue's event data, and the commit is again present in the related commits of the issue. This does not work if it is not possible to fetch that commit. In this case, the event still exists, but it contains a link to a commit that the api cannot resolve, meaning that no data about the commit can be accessed.
+Known causes of this include:
+
+- a commit was rebased and changed/removed
+- an external repository was deleted
+- the commit's branch was deleted
+
+Note that the commit might still be reachable until the automatic garbage collection has removed it from the remote repository.
+In itself, this is not problematic. However, when further processing the data using `codeface-extraction`, this may lead to these `referenced` events being present in the final data, even though they should be filtered out as part of the issue processing.

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ repo.getIssues(false).ifPresent(issueData -> issueData.forEach(issue -> {
 
 ### Further data processing
 
-The data extracted by this tool can be further processed, for example using the `run-issues.py` skript from the tool [`codeface-extraction`](https://github.com/se-sic/codeface-extraction). This organises and unifies the issue data into a single .list file. It also allows for synchronisation with data from other data extraction tools, such as `codeface`.
+The data extracted by this tool can be further processed, for example using the `run-issues.py` script from the tool [`codeface-extraction`](https://github.com/se-sic/codeface-extraction). This organizes and unifies the issue data into a single csv-like .list file. It also allows for synchronization with data from other data extraction tools, such as `codeface`.
 
-### `Referenced` events
+### `referenced` events
 
-`Referenced` events are events generated in an issue if a commit references that issue in its commit message. The intended behavior is that the event is present in the issue's event data, and the commit is again present in the related commits of the issue. This does not work if it is not possible to fetch that commit. In this case, the event still exists, but it contains a link to a commit that the api cannot resolve, meaning that no data about the commit can be accessed.
+`referenced` events are events generated in an issue if a commit references that issue in its commit message. The intended behavior is that the event is present in the issue's event data, and the commit is again present in the related commits of the issue. This does not work if it is not possible to fetch that commit. In this case, the event still exists, but it contains a link to a commit that the api cannot resolve, meaning that no data about the commit can be accessed.
 Known causes of this include:
 
 - a commit was rebased and changed/removed

--- a/src/de/uni_passau/fim/gitwrapper/EventDataProcessor.java
+++ b/src/de/uni_passau/fim/gitwrapper/EventDataProcessor.java
@@ -86,8 +86,12 @@ class EventDataProcessor implements JsonDeserializer<EventData>, JsonSerializer<
             }
 
             result.commit = repo.getGithubCommit(hash.getAsString()).orElseGet(() -> {
-                LOG.warning("Found commit unknown to GitHub and local git repo: " + hash);
-                return null;
+                LOG.warning("Found commit unknown to GitHub and local git repo: " + hash + " Retry using url...");
+                JsonElement url = src.getAsJsonObject().get("commit_url");
+                return repo.getGithubCommitUrl(hash.getAsString(), url.getAsString()).orElseGet(() -> {
+                    LOG.warning("Could not find commit: " + hash);
+                    return null;
+                });
             });
         }
 

--- a/src/de/uni_passau/fim/gitwrapper/EventDataProcessor.java
+++ b/src/de/uni_passau/fim/gitwrapper/EventDataProcessor.java
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) 2016-2018 Florian Heck
  * Copyright (C) 2019 Thomas Bock
+ * Copyright (C) 2025 Leo Sendelbach
  *
  * This file is part of GitHubWrapper.
  *

--- a/src/de/uni_passau/fim/gitwrapper/GitHubCommit.java
+++ b/src/de/uni_passau/fim/gitwrapper/GitHubCommit.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019 Thomas Bock
+ * Copyright (C) 2025 Leo Sendelbach
  *
  * This file is part of GitHubWrapper.
  *

--- a/src/de/uni_passau/fim/gitwrapper/GitHubCommit.java
+++ b/src/de/uni_passau/fim/gitwrapper/GitHubCommit.java
@@ -26,6 +26,7 @@ public class GitHubCommit extends Commit {
     private String authorUsername;
     private String committerUsername;
     private boolean addedToPullRequest = false;
+    private boolean isExternal = false;
 
     /**
      * Constructs a new {@link GitHubCommit} with the given <code>id</code> made in the <code>repo</code>.
@@ -118,5 +119,13 @@ public class GitHubCommit extends Commit {
      */
     void setAddedToPullRequest(boolean added) {
         this.addedToPullRequest = added;
+    }
+
+    void setExternal(boolean external) {
+        this.isExternal = true;
+    }
+
+    boolean getExternal() {
+        return this.isExternal;
     }
 }

--- a/src/de/uni_passau/fim/gitwrapper/GitHubCommit.java
+++ b/src/de/uni_passau/fim/gitwrapper/GitHubCommit.java
@@ -27,7 +27,7 @@ public class GitHubCommit extends Commit {
     private String authorUsername;
     private String committerUsername;
     private boolean addedToPullRequest = false;
-    private boolean isExternal = false;
+    private boolean external = false;
 
     /**
      * Constructs a new {@link GitHubCommit} with the given <code>id</code> made in the <code>repo</code>.
@@ -122,11 +122,22 @@ public class GitHubCommit extends Commit {
         this.addedToPullRequest = added;
     }
 
-    void setExternal(boolean external) {
-        this.isExternal = true;
+    /**
+     * Returns whether this commit is an external commit.
+     * 
+     * @return whether this commit is an external commit
+     */
+    boolean isExternal() {
+        return this.external;
     }
 
-    boolean getExternal() {
-        return this.isExternal;
+    /**
+     * Sets whether this commit is an external commit
+     * 
+     * @param external this commit is an external commit
+     */
+    void setExternal(boolean external) {
+        this.external = external;
     }
+    
 }

--- a/src/de/uni_passau/fim/gitwrapper/GitHubRepository.java
+++ b/src/de/uni_passau/fim/gitwrapper/GitHubRepository.java
@@ -2,6 +2,7 @@
  * Copyright (C) 2016-2020 Florian Heck
  * Copyright (C) 2018 Claus Hunsen
  * Copyright (C) 2019-2021 Thomas Bock
+ * Copyright (C) 2025 Leo Sendelbach
  *
  * This file is part of GitHubWrapper.
  *

--- a/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
+++ b/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
@@ -76,11 +76,13 @@ public class IssueDataProcessor implements JsonDeserializer<IssueDataCached>, Po
                 .filter(eventData -> eventData instanceof EventData.ReferencedEventData)
                 // filter out errors from referencing commits
                 .filter(eventData -> ((EventData.ReferencedEventData) eventData).commit != null)
-                .map(eventData -> {if (((GitHubCommit) ((EventData.ReferencedEventData) eventData).commit).getExternal())
-                { return new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssueExternal") ;
-            } else {
-                return new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssue");
-            }});
+                .map(eventData -> {
+                    if (((GitHubCommit) ((EventData.ReferencedEventData) eventData).commit).getExternal()) {
+                        return new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssueExternal");
+                    } else {
+                        return new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssue");
+                    }
+                });
 
         // Parse commits from reviews and reviews' comments
         if (issue.isPullRequest()) {

--- a/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
+++ b/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) 2016-2018 Florian Heck
  * Copyright (C) 2019-2020 Thomas Bock
+ * Copyright (C) 2025 Leo Sendelbach
  *
  * This file is part of GitHubWrapper.
  *

--- a/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
+++ b/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
@@ -76,7 +76,11 @@ public class IssueDataProcessor implements JsonDeserializer<IssueDataCached>, Po
                 .filter(eventData -> eventData instanceof EventData.ReferencedEventData)
                 // filter out errors from referencing commits
                 .filter(eventData -> ((EventData.ReferencedEventData) eventData).commit != null)
-                .map(eventData -> new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssue"));
+                .map(eventData -> {if (((GitHubCommit) ((EventData.ReferencedEventData) eventData).commit).getExternal())
+                { return new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssueExternal") ;
+            } else {
+                return new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssue");
+            }});
 
         // Parse commits from reviews and reviews' comments
         if (issue.isPullRequest()) {

--- a/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
+++ b/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
@@ -266,6 +266,15 @@ public class IssueDataProcessor implements JsonDeserializer<IssueDataCached>, Po
         }
         Pattern hashtagPattern;
 
+        // filter out everything in code block
+        String[] texts = text.split("```");
+        text = "";
+        for (int i = 0; i < texts.length; i++) {
+            if (i % 2 == 0) {
+                text = text + texts[i];
+            }
+        }
+
         if (onlyInSameRepo) {
             String repoName = repo.getRepoName();
             String repoUser = repo.getRepoUser();
@@ -383,6 +392,7 @@ public class IssueDataProcessor implements JsonDeserializer<IssueDataCached>, Po
             Optional<List<ReferencedLink<String>>> comments = repo.getComments(lookup);
             result.setComments(comments.orElse(Collections.emptyList()));
         }
+
         if (result.getEventsList() == null) {
             Optional<List<EventData>> events = repo.getEvents(lookup);
             result.setEvents(events.orElse(Collections.emptyList()));

--- a/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
+++ b/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
@@ -78,7 +78,7 @@ public class IssueDataProcessor implements JsonDeserializer<IssueDataCached>, Po
                 // filter out errors from referencing commits
                 .filter(eventData -> ((EventData.ReferencedEventData) eventData).commit != null)
                 .map(eventData -> {
-                    if (((GitHubCommit) ((EventData.ReferencedEventData) eventData).commit).getExternal()) {
+                    if (((GitHubCommit) ((EventData.ReferencedEventData) eventData).commit).isExternal()) {
                         return new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssueExternal");
                     } else {
                         return new ReferencedLink<>(Collections.singletonList(((EventData.ReferencedEventData) eventData).commit.getId()), eventData.user, eventData.created_at, "commitReferencesIssue");

--- a/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
+++ b/src/de/uni_passau/fim/gitwrapper/IssueDataProcessor.java
@@ -271,12 +271,13 @@ public class IssueDataProcessor implements JsonDeserializer<IssueDataCached>, Po
 
         // filter out everything in code block
         String[] texts = text.split("```");
-        text = "";
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < texts.length; i++) {
             if (i % 2 == 0) {
-                text = text + texts[i];
+                sb.append(texts[i]);
             }
         }
+        text = sb.toString();
 
         if (onlyInSameRepo) {
             String repoName = repo.getRepoName();


### PR DESCRIPTION
External commits that mention issues in the project can now be fetched. They receive a new type of related commit, called `commitReferencesIssueExternal`. Also fixed hashatags in markdown code environments incorrectly registering as references to other issues/PRs.